### PR TITLE
[Events] Order and split current/past events

### DIFF
--- a/hosting/src/_services/store/index.ts
+++ b/hosting/src/_services/store/index.ts
@@ -1,5 +1,6 @@
 import { User as FirebaseUser } from '@firebase/auth-types'
 import { InjectionKey } from '@vue/runtime-core'
+import dayjs from 'dayjs'
 import { createStore, Store } from 'vuex'
 import { firestoreAction, vuexfireMutations } from 'vuexfire'
 
@@ -54,7 +55,7 @@ export const store = createStore<PTStoreState>({
   actions: {
     init: firestoreAction(async ({ bindFirestoreRef }) => {
       return await Promise.all([
-        bindFirestoreRef(STORE.STATE.eventsRaw, db.collection(EVENTS)),
+        bindFirestoreRef(STORE.STATE.eventsRaw, db.collection(EVENTS).orderBy('dateStart', 'desc')),
         bindFirestoreRef(STORE.STATE.banners, db.collection(BANNERS).where('dateExpire', '>', new Date()))
       ])
     }),

--- a/hosting/src/_services/store/index.ts
+++ b/hosting/src/_services/store/index.ts
@@ -1,6 +1,5 @@
 import { User as FirebaseUser } from '@firebase/auth-types'
 import { InjectionKey } from '@vue/runtime-core'
-import dayjs from 'dayjs'
 import { createStore, Store } from 'vuex'
 import { firestoreAction, vuexfireMutations } from 'vuexfire'
 

--- a/hosting/src/events/Events/EventRow.html
+++ b/hosting/src/events/Events/EventRow.html
@@ -9,9 +9,8 @@
               : { backgroundImage: 'url(/images/banner_16_9_default.jpg)'}"
         ></div>
       </div>
-      <p class="mt-3 text-center">
+      <p class="mt-3 text-center hidden">
         <router-link
-          v-if="true"
           :to="{ name: 'Event', params: { slug: event.slug } }"
           class="text-brand-blue-900 hover:text-brand-blue-500"
           >&gt; &gt; Register Now &lt; &lt;</router-link
@@ -21,7 +20,7 @@
     <div class="col-span-1 sm:col-span-2">
       <router-link
         :to="{ name: 'Event', params: { slug: event.slug } }"
-        class="text-xl text-brand-blue-900 hover:text-brand-blue-500"
+        class="text-2xl text-brand-blue-900 hover:text-brand-blue-500"
         >{{ event.name }}
         <div
           v-if="event.series && event.seriesType"
@@ -41,7 +40,7 @@
           {{ event.seriesType }}
         </div>
       </router-link>
-      <p class="text-xs text-gray-400">
+      <p class="text-gray-400 mt-1">
         {{ $filters.eventDate(event) }} @ {{ event.location }}
       </p>
       <div v-if="event.description" class="my-4">{{ event.description }}</div>
@@ -52,6 +51,7 @@
           bg-brand-black-50
           rounded-sm
           text-xs
+          lowercase
           py-0.5
           px-1.5
           mr-1.5

--- a/hosting/src/events/Events/EventRow.html
+++ b/hosting/src/events/Events/EventRow.html
@@ -1,0 +1,64 @@
+<div class="py-4 px-4 ring-2 ring-gray-100 rounded-xl mb-6 bg-gray-50">
+  <div class="grid grid-cols-1 sm:grid-cols-3 gap-x-5 gap-y-4">
+    <div class="col-span-1">
+      <div class="aspect-w-16 aspect-h-9 w-full">
+        <div
+          class="w-full h-full bg-cover bg-top rounded-lg shadow-lg"
+          :style="event.bannerUrl 
+              ? { backgroundImage: 'url(' + event.bannerUrl + ')' } 
+              : { backgroundImage: 'url(/images/banner_16_9_default.jpg)'}"
+        ></div>
+      </div>
+      <p class="mt-3 text-center">
+        <router-link
+          v-if="true"
+          :to="{ name: 'Event', params: { slug: event.slug } }"
+          class="text-brand-blue-900 hover:text-brand-blue-500"
+          >&gt; &gt; Register Now &lt; &lt;</router-link
+        >
+      </p>
+    </div>
+    <div class="col-span-1 sm:col-span-2">
+      <router-link
+        :to="{ name: 'Event', params: { slug: event.slug } }"
+        class="text-xl text-brand-blue-900 hover:text-brand-blue-500"
+        >{{ event.name }}
+        <div
+          v-if="event.series && event.seriesType"
+          class="
+            inline-block
+            align-middle
+            bg-brand-black
+            text-brand-blue-500
+            rounded-sm
+            text-xs
+            px-1
+            py-0.5
+            mb-1
+            ml-0.5
+          "
+        >
+          {{ event.seriesType }}
+        </div>
+      </router-link>
+      <p class="text-xs text-gray-400">
+        {{ $filters.eventDate(event) }} @ {{ event.location }}
+      </p>
+      <div v-if="event.description" class="my-4">{{ event.description }}</div>
+      <div
+        v-for="badge in event.badges"
+        class="
+          inline-block
+          bg-brand-black-50
+          rounded-sm
+          text-xs
+          py-0.5
+          px-1.5
+          mr-1.5
+        "
+      >
+        {{ badge }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/hosting/src/events/Events/EventRow.ts
+++ b/hosting/src/events/Events/EventRow.ts
@@ -1,0 +1,9 @@
+import { Vue } from 'vue-class-component'
+import { Prop } from 'vue-property-decorator'
+
+import { EventUi } from '../models'
+
+export default class EventRow extends Vue {
+  @Prop()
+  event!: EventUi
+}

--- a/hosting/src/events/Events/EventRow.vue
+++ b/hosting/src/events/Events/EventRow.vue
@@ -1,0 +1,2 @@
+<template src="./EventRow.html"></template>
+<script src="./EventRow.ts" lang="ts"></script>

--- a/hosting/src/events/Events/Events.html
+++ b/hosting/src/events/Events/Events.html
@@ -1,7 +1,7 @@
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-8 sm:mt-6">
   <h1 class="text-3xl font-medium text-brand-black pb-8">Upcoming Events</h1>
   <EventRow
-    v-for="event in currentEvents"
+    v-for="event in futureEvents"
     :key="'event' + event.slug"
     :event="event"
   />

--- a/hosting/src/events/Events/Events.html
+++ b/hosting/src/events/Events/Events.html
@@ -1,75 +1,15 @@
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-8 sm:mt-6">
   <h1 class="text-3xl font-medium text-brand-black pb-8">Upcoming Events</h1>
-
-  <div
-    v-for="event in events"
+  <EventRow
+    v-for="event in currentEvents"
     :key="'event' + event.slug"
-    class="py-4 px-4 ring-2 ring-gray-100 rounded-xl mb-6 bg-gray-50"
-  >
-    <div class="grid grid-cols-1 sm:grid-cols-3 gap-x-5 gap-y-4">
-      <div class="col-span-1">
-        <div class="aspect-w-16 aspect-h-9 w-full">
-          <div
-            class="w-full h-full bg-cover bg-top rounded-lg shadow-lg"
-            :style="event.bannerUrl 
-              ? { backgroundImage: 'url(' + event.bannerUrl + ')' } 
-              : { backgroundImage: 'url(/images/banner_16_9_default.jpg)'}"
-          ></div>
-        </div>
-        <p class="mt-3 text-center">
-          <router-link
-            v-if="true"
-            :to="{ name: 'Event', params: { slug: event.slug } }"
-            class="text-brand-blue-900 hover:text-brand-blue-500"
-            >&gt; &gt; Register Now &lt; &lt;</router-link
-          >
-        </p>
-      </div>
-      <div class="col-span-1 sm:col-span-2">
-        <router-link
-          :to="{ name: 'Event', params: { slug: event.slug } }"
-          class="text-xl text-brand-blue-900 hover:text-brand-blue-500"
-          >{{ event.name }}
-          <div
-            v-if="event.series && event.seriesType"
-            class="
-              inline-block
-              align-middle
-              bg-brand-black
-              text-brand-blue-500
-              rounded-sm
-              text-xs
-              px-1
-              py-0.5
-              mb-1
-              ml-0.5
-            "
-          >
-            {{ event.seriesType }}
-          </div>
-        </router-link>
-        <p class="text-xs text-gray-400">
-          {{ $filters.eventDate(event) }} @ {{ event.location }}
-        </p>
-        <div v-if="event.description" class="my-4">{{ event.description }}</div>
-        <div
-          v-for="badge in event.badges"
-          class="
-            inline-block
-            bg-brand-black-50
-            rounded-sm
-            text-xs
-            py-0.5
-            px-1.5
-            mr-1.5
-          "
-        >
-          {{ badge }}
-        </div>
-      </div>
-    </div>
-  </div>
+    :event="event"
+  />
 
   <h1 class="text-3xl font-medium text-brand-black pb-8">Past Events</h1>
-  <p>TBD</p>
+  <EventRow
+    v-for="event in pastEvents"
+    :key="'event' + event.slug"
+    :event="event"
+  />
 </div>

--- a/hosting/src/events/Events/Events.ts
+++ b/hosting/src/events/Events/Events.ts
@@ -1,14 +1,24 @@
-import { Vue } from 'vue-class-component'
+import dayjs from 'dayjs'
+import { Options, Vue } from 'vue-class-component'
 import { useMeta } from 'vue-meta'
 
 import { Route } from '~/router/route-decorator'
 import { EventUi } from '../models'
 
+import EventRow from './EventRow.vue'
+
 @Route({ path: '/events' })
+@Options({ components: { EventRow } })
 export default class Events extends Vue {
   meta = useMeta({ title: 'Events' })
 
-  get events(): EventUi[] {
-    return this.$store.getters.events
+  get currentEvents(): EventUi[] {
+    const now = dayjs()
+    return this.$store.getters.events.filter((event: EventUi) => event.dateStart.isAfter(now)).reverse()
+  }
+
+  get pastEvents(): EventUi[] {
+    const now = dayjs()
+    return this.$store.getters.events.filter((event: EventUi) => event.dateStart.isBefore(now))
   }
 }

--- a/hosting/src/events/Events/Events.ts
+++ b/hosting/src/events/Events/Events.ts
@@ -12,7 +12,7 @@ import EventRow from './EventRow.vue'
 export default class Events extends Vue {
   meta = useMeta({ title: 'Events' })
 
-  get currentEvents(): EventUi[] {
+  get futureEvents(): EventUi[] {
     const now = dayjs()
     return this.$store.getters.events.filter((event: EventUi) => event.dateStart.isAfter(now)).reverse()
   }


### PR DESCRIPTION
## ✅ DoD

- [x] All work is complete
- [x] Migrations: NA
- [x] Documentation: NA
- [x] Release notes: NA
- [x] Issues linked: resolves _none_

## 🛑 Problems

_None_

## 📝 Summary

- Add ordering to the events
- Split events page into current and past
- _Refactor event row to separate component_

## 💡 More ideas

_None_

## 📸 Screenshots

![localhost_8080_events](https://user-images.githubusercontent.com/1175362/119214342-4ce62280-baf0-11eb-9902-20c86b806cb3.png)

