### PR TITLE
[Banners] Add priority; sort by priority/expiry

### DIFF
--- a/admin/src/seeds/emu/banners.ts
+++ b/admin/src/seeds/emu/banners.ts
@@ -8,24 +8,28 @@ export const banners: Banner[] = [
     slug: 'js-phs-1',
     banner169Url: 'https://storage.googleapis.com/phits-tech-emu.appspot.com/events/2021/js-phs-1.png',
     targetEventSlug: 'js-phs-1',
-    dateExpire: firebase.firestore.Timestamp.fromMillis(dayjs('2021-05-15T00:00:00.000+07:00').unix() * 1000) // temporary (auto-expires)
+    dateExpire: firebase.firestore.Timestamp.fromMillis(dayjs('2021-05-15T00:00:00.000+07:00').unix() * 1000), // temporary (auto-expires)
+    priority: 1
   },
   {
     slug: 'google-io-2021',
     banner169Url: 'https://storage.googleapis.com/phits-tech-emu.appspot.com/events/2021/google-io-2021.png',
     targetEventSlug: 'google-io-2021',
-    dateExpire: firebase.firestore.Timestamp.fromMillis(dayjs('2021-05-20T00:00:00.000+07:00').unix() * 1000) // temporary (auto-expires)
+    dateExpire: firebase.firestore.Timestamp.fromMillis(dayjs('2021-05-20T00:00:00.000+07:00').unix() * 1000), // temporary (auto-expires)
+    priority: 1
   },
   {
     slug: 'js-phs-2',
     banner169Url: 'https://storage.googleapis.com/phits-tech-emu.appspot.com/events/2021/js-phs-2.png',
     targetEventSlug: 'js-phs-2',
-    dateExpire: firebase.firestore.Timestamp.fromMillis(dayjs('2021-06-12T00:00:00.000+07:00').unix() * 1000) // temporary (auto-expires)
+    dateExpire: firebase.firestore.Timestamp.fromMillis(dayjs('2021-06-12T00:00:00.000+07:00').unix() * 1000), // temporary (auto-expires)
+    priority: 1
   },
   {
     slug: 'otap-2021-1',
     banner169Url: 'https://storage.googleapis.com/phits-tech-emu.appspot.com/events/2021/otap-2021-1.png',
     targetUrl: 'https://otap.phits.tech',
-    dateExpire: firebase.firestore.Timestamp.fromMillis(dayjs('2050-01-01T12:00:00.000+07:00').unix() * 1000) // permanent (manually expire by update)
+    dateExpire: firebase.firestore.Timestamp.fromMillis(dayjs('2050-01-01T12:00:00.000+07:00').unix() * 1000), // permanent (manually expire by update)
+    priority: 0
   }
 ]

--- a/common/src/dao-firestore/model-types.ts
+++ b/common/src/dao-firestore/model-types.ts
@@ -113,4 +113,5 @@ export interface Banner {
   targetEventSlug?: string
   targetRoute?: string
   dateExpire: Timestamp
+  priority: number
 }

--- a/hosting/src/Home/HomeBanners.ts
+++ b/hosting/src/Home/HomeBanners.ts
@@ -42,7 +42,7 @@ export default class Home extends Vue {
   currentSlideIndex = 0
   nextSlideInterval?: NodeJS.Timeout = undefined
 
-  get banners(): Array<Omit<Banner, 'slug' | 'dateExpire'>> { return this.$store.state.banners }
+  get banners(): Array<Omit<Banner, 'slug' | 'dateExpire'>> { return this.$store.state.banners.sort((b1, b2) => (b2.priority - b1.priority) || (b1.dateExpire.seconds - b2.dateExpire.seconds)) }
 
   mounted(): void { this.resetSlideTimer() }
   beforeUpdate(): void { this.currentSlideIndex = 0; this.bannerSlides = [] }

--- a/hosting/src/Home/HomeBanners.ts
+++ b/hosting/src/Home/HomeBanners.ts
@@ -42,7 +42,7 @@ export default class Home extends Vue {
   currentSlideIndex = 0
   nextSlideInterval?: NodeJS.Timeout = undefined
 
-  get banners(): Array<Omit<Banner, 'slug' >> { return this.$store.state.banners.sort((b1, b2) => (b2.priority - b1.priority) || (b1.dateExpire.seconds - b2.dateExpire.seconds)) }
+  get banners(): Array<Omit<Banner, 'slug'>> { return this.$store.state.banners.sort((b1, b2) => (b2.priority - b1.priority) || (b1.dateExpire.seconds - b2.dateExpire.seconds)) }
 
   mounted(): void { this.resetSlideTimer() }
   beforeUpdate(): void { this.currentSlideIndex = 0; this.bannerSlides = [] }

--- a/hosting/src/Home/HomeBanners.ts
+++ b/hosting/src/Home/HomeBanners.ts
@@ -42,7 +42,7 @@ export default class Home extends Vue {
   currentSlideIndex = 0
   nextSlideInterval?: NodeJS.Timeout = undefined
 
-  get banners(): Array<Omit<Banner, 'slug' | 'dateExpire'>> { return this.$store.state.banners.sort((b1, b2) => (b2.priority - b1.priority) || (b1.dateExpire.seconds - b2.dateExpire.seconds)) }
+  get banners(): Array<Omit<Banner, 'slug' >> { return this.$store.state.banners.sort((b1, b2) => (b2.priority - b1.priority) || (b1.dateExpire.seconds - b2.dateExpire.seconds)) }
 
   mounted(): void { this.resetSlideTimer() }
   beforeUpdate(): void { this.currentSlideIndex = 0; this.bannerSlides = [] }

--- a/hosting/src/_services/store/index.ts
+++ b/hosting/src/_services/store/index.ts
@@ -14,7 +14,7 @@ import { db } from '~/firebase-initialized'
 export interface PTStoreState {
   currentUser: DeepRequiredWithId<User> | null
   eventsRaw: Array<DeepRequired<Event>>
-  banners: Array<Omit<Banner, 'slug' | 'dateExpire'>>
+  banners: Array<Omit<Banner, 'slug' >>
 }
 
 /**
@@ -40,7 +40,7 @@ export const store = createStore<PTStoreState>({
   state: {
     currentUser: null, // eslint-disable-line unicorn/no-null -- vuexfire
     eventsRaw: [],
-    banners: [{ banner169Url: '/images/placeholders/banner_16_9_loading.png' }]
+    banners: []
   },
   getters: {
     events: state => state.eventsRaw.map(event => eventToEventUi(event)),


### PR DESCRIPTION
## ✅ DoD

- [x] All work is complete
- [x] Migrations: NA
- [x] Issues linked: resolves #79

## 📝 Summary

- Add a field priority (with type number)
- Update `banners()` to sort by priority & expiry
- Set the priority of example banners to 1; except OTAP "perma-banner" (which is 0)

## 💉 Testing

- Tested locally (yarn watch; yarn emu; yarn seed && yarn dev)

## 📸 Screenshots

**Highest priority shows first:**
![image](https://user-images.githubusercontent.com/82072741/121310926-156bd880-c92e-11eb-9ff4-d0a159d140b9.png)